### PR TITLE
Added `bevy_auto_plugin` feature.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,14 +31,14 @@ checksum = "f548ad2c4031f2902e3edc1f29c29e835829437de49562d8eb5dc5584d3a1043"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -59,13 +59,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -79,52 +79,53 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bevy"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5cd3b24a5adb7c7378da7b3eea47639877643d11b6b087fc8a8094f2528615"
+checksum = "4b8369c16b7c017437021341521f8b4a0d98e1c70113fb358c3258ae7d661d79"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy-butler"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3110fa6c59f9c5cbb3719b120f736f95fdf440d8034911a147f72efec691a85a"
+checksum = "a837ab609be8353552de441031ee101ac86ffb19ccf9e6d3d2b922aa545f0ff9"
 dependencies = [
  "bevy-butler-proc-macro",
  "bevy_app",
  "bevy_ecs",
  "bevy_log",
+ "bevy_state",
  "inventory",
  "linkme",
 ]
 
 [[package]]
 name = "bevy-butler-proc-macro"
-version = "0.6.1"
+version = "0.6.2-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ee12e4ffa2725714bc68e942229724df006607e68b5fc244a9916814ff635"
+checksum = "4150a4732c48044ec63efd1ebe51a889647391dab5e59603802eac3a1bde63b0"
 dependencies = [
  "deluxe",
  "deluxe-core",
  "proc-macro2",
  "quote",
  "sha256",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "bevy_app"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b6267ac23a9947d5b2725ff047a1e1add70076d85fa9fb73d044ab9bea1f3c"
+checksum = "4491cc4c718ae76b4c6883df58b94cc88b32dcd894ea8d5b603c7c7da72ca967"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -144,21 +145,69 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_derive"
-version = "0.16.0"
+name = "bevy_auto_plugin"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f626531b9c05c25a758ede228727bd11c2c2c8498ecbed9925044386d525a2a3"
+checksum = "71599f6ff43778a56d1c9d257bcaf257abdae3385c8c2be883646dd64d1bbb93"
+dependencies = [
+ "bevy_auto_plugin_proc_macros",
+ "bevy_auto_plugin_shared",
+ "cfg_aliases",
+ "rustc_version",
+]
+
+[[package]]
+name = "bevy_auto_plugin_proc_macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07922d132befe18e2878cd170ba80110437d509e265f4c138617766191fb22a6"
+dependencies = [
+ "bevy_auto_plugin_shared",
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "bevy_auto_plugin_shared"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10522f47da314c6a708f3c2001db6eaa0e94a44f06462700e57d1a28a7cdcc54"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_ecs_macros",
+ "bevy_log",
+ "bevy_reflect",
+ "bevy_reflect_derive",
+ "bevy_state",
+ "darling",
+ "inventory",
+ "linkme",
+ "proc-macro2",
+ "quote",
+ "smart-default",
+ "syn 2.0.106",
+ "thiserror",
+]
+
+[[package]]
+name = "bevy_derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b837bf6c51806b10ebfa9edf1844ad80a3a0760d6c5fac4e90761df91a8901a"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048a1ff3944a534b8472516866284181eef0a75b6dd4d39b6e5925715e350766"
+checksum = "48797366f312a8f31e237d08ce3ee70162591282d2bfe7c5ad8be196fb263e55"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -172,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e807b5d9aab3bb8dfe47e7a44c9ff088bad2ceefe299b80ac77609a87fe9d4"
+checksum = "3c2bf6521aae57a0ec3487c4bfb59e36c4a378e834b626a4bea6a885af2fdfe7"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -200,21 +249,21 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d7bb98aeb8dd30f36e6a773000c12a891d4f1bee2adc3841ec89cc8eaf54e"
+checksum = "38748d6f3339175c582d751f410fb60a93baf2286c3deb7efebb0878dce7f413"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "bevy_input"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763410715714f3d4d2dcdf077af276e2e4ea93fd8081b183d446d060ea95baaa"
+checksum = "18d6b6516433f6f7d680f648d04eb1866bb3927a1782d52f74831b62042f3cd1"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -229,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526ffd64c58004cb97308826e896c07d0e23dc056c243b97492e31cdf72e2830"
+checksum = "857da8785678fde537d02944cd20dec9cafb7d4c447efe15f898dc60e733cacd"
 dependencies = [
  "bevy_app",
  "bevy_derive",
@@ -250,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7156df8d2f11135cf71c03eb4c11132b65201fd4f51648571e59e39c9c9ee2f6"
+checksum = "d7a61ee8aef17a974f5ca481dcedf0c2bd52670e231d4c4bc9ddef58328865f9"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -267,22 +316,22 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2473db70d8785b5c75d6dd951a2e51e9be2c2311122db9692c79c9d887517b"
+checksum = "052eeebcb8e7e072beea5031b227d9a290f8a7fbbb947573ab6ec81df0fb94be"
 dependencies = [
  "parking_lot",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
- "toml_edit 0.22.26",
+ "syn 2.0.106",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
 name = "bevy_math"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a3a926d02dc501c6156a047510bdb538dcb1fa744eeba13c824b73ba88de55"
+checksum = "68553e0090fe9c3ba066c65629f636bd58e4ebd9444fdba097b91af6cd3e243f"
 dependencies = [
  "bevy_reflect",
  "derive_more",
@@ -299,15 +348,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_platform"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704db2c11b7bc31093df4fbbdd3769f9606a6a5287149f4b51f2680f25834ebc"
+checksum = "f7573dc824a1b08b4c93fdbe421c53e1e8188e9ca1dd74a414455fe571facb47"
 dependencies = [
  "cfg-if",
  "critical-section",
  "foldhash",
  "getrandom 0.2.16",
- "hashbrown",
+ "hashbrown 0.15.5",
  "portable-atomic",
  "portable-atomic-util",
  "serde",
@@ -317,15 +366,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f1275dfb4cfef4ffc90c3fa75408964864facf833acc932413d52aa5364ba4"
+checksum = "df7370d0e46b60e071917711d0860721f5347bc958bf325975ae6913a5dfcf01"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607ebacc31029cf2f39ac330eabf1d4bc411b159528ec08dbe6b0593eaccfd41"
+checksum = "daeb91a63a1a4df00aa58da8cc4ddbd4b9f16ab8bb647c5553eb156ce36fa8c2"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -349,22 +398,50 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf35e45e4eb239018369f63f2adc2107a54c329f9276d020e01eee1625b0238b"
+checksum = "40ddadc55fe16b45faaa54ab2f9cb00548013c74812e8b018aa172387103cce6"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
  "uuid",
 ]
 
 [[package]]
-name = "bevy_tasks"
-version = "0.16.0"
+name = "bevy_state"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444c450b65e108855f42ecb6db0c041a56ea7d7f10cc6222f0ca95e9536a7d19"
+checksum = "155d3cd97b900539008cdcaa702f88b724d94b08977b8e591a32536ce66faa8c"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_state_macros",
+ "bevy_utils",
+ "log",
+ "variadics_please",
+]
+
+[[package]]
+name = "bevy_state_macros"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2481c1304fd2a1851a0d4cb63a1ce6421ae40f3f0117cbc9882963ee4c9bb609"
+dependencies = [
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "bevy_tasks"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b674242641cab680688fc3b850243b351c1af49d4f3417a576debd6cca8dcf5"
 dependencies = [
  "async-executor",
  "async-task",
@@ -382,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456369ca10f8e039aaf273332744674844827854833ee29e28f9e161702f2f55"
+checksum = "bc98eb356c75be04fbbc77bb3d8ffa24c8bacd99f76111cee23d444be6ac8c9c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -395,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8479cdd5461246943956a7c8347e4e5d6ff857e57add889fb50eee0b5c26ab48"
+checksum = "df218e440bb9a19058e1b80a68a031c887bcf7bd3a145b55f361359a2fa3100d"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -411,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2da3b3c1f94dadefcbe837aaa4aa119fcea37f7bdc5307eb05b4ede1921e24"
+checksum = "94f7a8905a125d2017e8561beefb7f2f5e67e93ff6324f072ad87c5fd6ec3b99"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -436,14 +513,14 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 dependencies = [
  "serde",
 ]
@@ -459,15 +536,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "byteorder"
@@ -483,10 +560,11 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -501,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -590,19 +668,20 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.6"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
+checksum = "881c5d0a13b2f1498e2306e82cbada78390e152d4b1378fb28a84f4dcd0dc4f3"
 dependencies = [
+ "dispatch",
  "nix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -610,27 +689,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -643,7 +722,7 @@ dependencies = [
  "deluxe-macros",
  "once_cell",
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -656,7 +735,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -671,7 +750,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -691,7 +770,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
  "unicode-xid",
 ]
 
@@ -706,6 +785,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
 name = "disqualified"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,9 +798,9 @@ checksum = "c9c272297e804878a2a4b707cfcfc6d2328b5bb936944613b4fdf2b9269afdfd"
 
 [[package]]
 name = "downcast-rs"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "either"
@@ -731,11 +816,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+checksum = "259d404d09818dec19332e31d94558aeb442fea04c817006456c24b5460bbd4b"
 dependencies = [
  "serde",
+ "serde_core",
  "typeid",
 ]
 
@@ -744,6 +830,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "fixedbitset"
@@ -786,9 +878,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -816,20 +908,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -845,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hash32"
@@ -860,13 +952,19 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "equivalent",
  "serde",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heapless"
@@ -899,9 +997,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "if_chain"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
 name = "immediate_stats"
@@ -910,6 +1008,7 @@ dependencies = [
  "bevy",
  "bevy-butler",
  "bevy_app",
+ "bevy_auto_plugin",
  "bevy_ecs",
  "bevy_reflect",
  "immediate_stats_macros",
@@ -923,24 +1022,24 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
 name = "inventory"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
 dependencies = [
  "rustversion",
 ]
@@ -965,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -981,51 +1080,51 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linkme"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d227772b5999ddc0690e733f734f95ca05387e329c4084fe65678c51198ffe"
+checksum = "a1b1703c00b2a6a70738920544aa51652532cacddfec2e162d2e29eae01e665c"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a98813fa0073a317ed6a8055dcd4722a49d9b862af828ee68449adb799b6be"
+checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1033,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "matchers"
@@ -1048,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "minimal-lexical"
@@ -1060,9 +1159,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1119,9 +1218,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1129,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1157,7 +1256,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1168,9 +1267,9 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1192,12 +1291,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1236,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -1254,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1300,18 +1399,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1321,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1332,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rustc-hash"
@@ -1343,10 +1442,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustversion"
-version = "1.0.20"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "scopeguard"
@@ -1355,23 +1463,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1414,18 +1538,26 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "smol_str"
@@ -1475,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1486,39 +1618,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
@@ -1533,13 +1664,13 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.7.8",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -1555,20 +1686,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1643,9 +1774,9 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-xid"
@@ -1655,11 +1786,11 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -1679,7 +1810,7 @@ checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1690,50 +1821,60 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1744,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1754,31 +1895,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1808,6 +1949,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,11 +1965,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -1900,38 +2047,35 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.8"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
 name = "immediate_stats"
-version = "0.1.3"
+version = "0.2.0-beta.1"
 dependencies = [
  "bevy",
  "bevy-butler",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "immediate_stats_macros"
-version = "0.1.3"
+version = "0.2.0-beta.1"
 dependencies = [
  "darling",
  "proc-macro-error",

--- a/README.md
+++ b/README.md
@@ -48,25 +48,24 @@ fn main() {
 }
 ```
 
-### Bevy Butler
+### Bevy Auto Plugin
 
-If you use [Bevy Butler](https://github.com/TGRCdev/bevy-butler/), you can also use the `bevy_butler` feature flag.
-This automatically registers the required system(s) using the `add_component` attribute
-or the existing `insert_resource` macro.
+If you use [Bevy Auto Plugin](https://github.com/strikeforcezero/bevy_auto_plugin/), you can also use the `bevy_auto_plugin` feature flag.
+This automatically registers the required system(s) by leveraging the existing `auto_component` and `auto_resource` macros.
 
 ```rust
 fn main() {
     App::new().add_plugins((ImmediateStatsPlugin, MyPlugin)).run();
 }
 
-#[butler_plugin]
+#[derive(AutoPlugin)]
+#[auto_plugin(impl_plugin_trait)]
 struct MyPlugin;
 
-// `StatContainer` derive adds the `add_component` attribute 
-// and hooks into the existing `insert_resource` macro.
+// `StatContainer` derive hooks into the existing `auto_component` and `auto_resource` macros.
 #[derive(StatContainer, Component, Resource)]
-#[add_component(plugin = MyPlugin)] // Adds `reset_component_modifiers` system.
-#[insert_resource(plugin = MyPlugin)] // Adds `reset_resource_modifiers` system.
+#[auto_component(plugin = MyPlugin)] // Adds `reset_component_modifiers` system.
+#[auto_init_resource(plugin = MyPlugin)] // Adds `reset_resource_modifiers` system.
 struct Speed(Stat);
 ```
 

--- a/immediate_stats/Cargo.toml
+++ b/immediate_stats/Cargo.toml
@@ -14,14 +14,25 @@ readme = "../README.md"
 all-features = true
 
 [features]
-bevy = ["bevy_ecs", "bevy_app", "bevy_reflect", "immediate_stats_macros/bevy"]
-bevy_butler = ["bevy", "bevy-butler", "immediate_stats_macros/bevy_butler"]
+bevy = [
+  "dep:bevy_ecs",
+  "dep:bevy_app",
+  "dep:bevy_reflect",
+  "immediate_stats_macros/bevy",
+]
+bevy_butler = ["bevy", "dep:bevy-butler", "immediate_stats_macros/bevy_butler"]
+bevy_auto_plugin = [
+  "bevy",
+  "dep:bevy_auto_plugin",
+  "immediate_stats_macros/bevy_auto_plugin",
+]
 
 [dependencies]
 bevy_app = { version = "0.16.0", default-features = false, optional = true, features = [
   "bevy_reflect",
 ] }
 bevy-butler = { version = "0.6.1", optional = true }
+bevy_auto_plugin = { version = "0.5.0", optional = true }
 bevy_ecs = { version = "0.16.0", default-features = false, optional = true, features = [
   "bevy_reflect",
 ] }
@@ -51,3 +62,8 @@ required-features = ["bevy"]
 name = "simple_bevy_butler"
 path = "examples/simple_bevy_butler.rs"
 required-features = ["bevy_butler"]
+
+[[example]]
+name = "simple_bevy_auto_plugin"
+path = "examples/simple_bevy_auto_plugin.rs"
+required-features = ["bevy_auto_plugin"]

--- a/immediate_stats/Cargo.toml
+++ b/immediate_stats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "immediate_stats"
-version = "0.1.3"
+version = "0.2.0-beta.1"
 edition = "2024"
 description = "Game stats that reset every frame, inspired by immediate mode GUI."
 categories = ["game-development", "data-structures"]
@@ -37,7 +37,7 @@ bevy_ecs = { version = "0.16.0", default-features = false, optional = true, feat
   "bevy_reflect",
 ] }
 bevy_reflect = { version = "0.16.0", default-features = false, optional = true }
-immediate_stats_macros = { path = "../immediate_stats_macros", version = "0.1.3", default-features = false }
+immediate_stats_macros = { path = "../immediate_stats_macros", version = "0.2.0-beta.1", default-features = false }
 
 [dev-dependencies]
 bevy = { version = "0.16.0", default-features = false }

--- a/immediate_stats/examples/simple_bevy_auto_plugin.rs
+++ b/immediate_stats/examples/simple_bevy_auto_plugin.rs
@@ -1,8 +1,9 @@
-//! A very simple example using Bevy Butler. Requires the `bevy_butler` feature flag, which is depreciated.
-//! Please see the Bevy Auto Plugin example instead.
+//! A very simple example using Bevy Auto Plugin. Requires the `bevy_auto_plugin` feature flag.
+//! There are two other versions of this example, one using a simple main loop and the other using Bevy.
 
 use bevy::prelude::*;
-use bevy_butler::*;
+use bevy_auto_plugin;
+use bevy_auto_plugin::modes::global::prelude::{AutoPlugin, auto_component, auto_system};
 use immediate_stats::*;
 
 fn main() {
@@ -11,21 +12,22 @@ fn main() {
         .run();
 }
 
-#[butler_plugin]
+#[derive(AutoPlugin)]
+#[auto_plugin(impl_plugin_trait)]
 struct SpeedPlugin;
 
 // Implements `reset_modifiers` by passing the call onto `Stat`.
 // This will also add the `ResetComponentPlugin` to `SpeedPlugin`.
 #[derive(StatContainer, Component)]
-#[add_component(plugin = SpeedPlugin)]
+#[auto_component(plugin = SpeedPlugin)]
 struct Speed(Stat);
 
-#[add_system(plugin = SpeedPlugin, schedule = Startup)]
+#[auto_system(plugin = SpeedPlugin, schedule = Startup)]
 fn init_speed(mut commands: Commands) {
     commands.spawn(Speed(Stat::new(10))); // Set base speed to 10.
 }
 
-#[add_system(plugin = SpeedPlugin, schedule = Update, in_set = StatSystems::Modify)]
+#[auto_system(plugin = SpeedPlugin, schedule = Update, config(in_set = StatSystems::Modify))]
 fn apply_modifiers(mut speeds: Query<&mut Speed>) {
     for mut speed in &mut speeds {
         speed.0 *= 2.0; // Applies a multiplier to the final result.
@@ -34,7 +36,7 @@ fn apply_modifiers(mut speeds: Query<&mut Speed>) {
     }
 }
 
-#[add_system(plugin = SpeedPlugin, schedule = Update, in_set = StatSystems::Read)]
+#[auto_system(plugin = SpeedPlugin, schedule = Update, config(in_set = StatSystems::Read))]
 fn read_speed(speeds: Query<&Speed>) {
     for speed in &speeds {
         println!("The current speed is {}.", speed.0.total());

--- a/immediate_stats/examples/simple_bevy_butler.rs
+++ b/immediate_stats/examples/simple_bevy_butler.rs
@@ -1,5 +1,5 @@
 //! A very simple example using Bevy Butler. Requires the `bevy_butler` feature flag, which is *depreciated*.
-//! 
+//!
 //! **Please see the Bevy Auto Plugin example instead.**
 
 use bevy::prelude::*;

--- a/immediate_stats/examples/simple_bevy_butler.rs
+++ b/immediate_stats/examples/simple_bevy_butler.rs
@@ -1,5 +1,6 @@
-//! A very simple example using Bevy Butler. Requires the `bevy_butler` feature flag, which is depreciated.
-//! Please see the Bevy Auto Plugin example instead.
+//! A very simple example using Bevy Butler. Requires the `bevy_butler` feature flag, which is *depreciated*.
+//! 
+//! **Please see the Bevy Auto Plugin example instead.**
 
 use bevy::prelude::*;
 use bevy_butler::*;

--- a/immediate_stats/examples/simple_main_loop.rs
+++ b/immediate_stats/examples/simple_main_loop.rs
@@ -1,5 +1,5 @@
 //! A very simple example using a main loop.
-//! There are two other versions of this example, one using Bevy and the other using Bevy Butler.
+//! There are two other versions of this example, one using Bevy and the other using Bevy Auto Plugin.
 
 use immediate_stats::*;
 

--- a/immediate_stats/src/lib.rs
+++ b/immediate_stats/src/lib.rs
@@ -48,31 +48,30 @@
 //! }
 //! ```
 //!
-//! ### Bevy Butler
+//! ### Bevy Auto Plugin
 //!
-//! If you use [Bevy Butler](https://github.com/TGRCdev/bevy-butler/),
-//! you can also use the `bevy_butler` feature flag.
-//! This automatically registers the required system(s) using the `add_component` attribute
-//! or the existing `insert_resource` macro.
+//! If you use [Bevy Auto Plugin](https://github.com/strikeforcezero/bevy_auto_plugin/),
+//! you can also use the `bevy_auto_plugin` feature flag. This automatically registers the required
+//! system(s) by leveraging the existing `auto_component` and `auto_resource` macros.
 //!
-#![cfg_attr(not(feature = "bevy_butler"), doc = "```rust ignore")]
-#![cfg_attr(feature = "bevy_butler", doc = "```rust")]
+#![cfg_attr(not(feature = "bevy_auto_plugin"), doc = "```rust ignore")]
+#![cfg_attr(feature = "bevy_auto_plugin", doc = "```rust")]
 //! # use bevy_app::prelude::*;
 //! # use bevy_ecs::prelude::*;
 //! # use immediate_stats::*;
-//! # use bevy_butler::*;
+//! # use bevy_auto_plugin::modes::global::prelude::{AutoPlugin, auto_component, auto_init_resource};
 //! fn main() {
 //!     App::new().add_plugins((ImmediateStatsPlugin, MyPlugin)).run();
 //! }
 //!
-//! #[butler_plugin]
+//! #[derive(AutoPlugin)]
+//! #[auto_plugin(impl_plugin_trait)]
 //! struct MyPlugin;
 //!
-//! // `StatContainer` derive adds the `add_component` attribute
-//! // and hooks into the existing `insert_resource` macro.
-//! #[derive(StatContainer, Component, Resource, Default)]
-//! #[add_component(plugin = MyPlugin)] // Adds `ResetComponentPlugin`
-//! #[insert_resource(plugin = MyPlugin)] // Adds `ResetResourcePlugin`
+//! // `StatContainer` derive hooks into the existing `auto_component` and `auto_resource` macros.
+//! #[derive(StatContainer, Component, Resource)]
+//! #[auto_component(plugin = MyPlugin)] // Adds `reset_component_modifiers` system.
+//! #[auto_init_resource(plugin = MyPlugin)] // Adds `reset_resource_modifiers` system.
 //! struct Speed(Stat);
 //! ```
 //!
@@ -141,23 +140,24 @@ mod stat;
 ///     assert_eq!(partial.ignored, Stat::default().with_bonus(10));
 /// }
 /// ```
-/// # Bevy Butler
-/// If the `bevy_butler` feature flag is enabled, you may also use the `add_component` attribute
-/// or the existing `insert_resource` macro to register [`reset_component_modifiers`]
-/// and/or [`reset_resource_modifiers`] automatically.
-#[cfg_attr(not(feature = "bevy_butler"), doc = "```rust ignore")]
-#[cfg_attr(feature = "bevy_butler", doc = "```rust")]
-/// # use bevy_butler::*;
+/// # Bevy Auto Plugin
+/// If the `bevy_auto_plugin` feature flag is enabled, the existing `auto_component` and
+/// `auto_resource` macros will register [`reset_component_modifiers`] and/or
+/// [`reset_resource_modifiers`] automatically.
+#[cfg_attr(not(feature = "bevy_auto_plugin"), doc = "```rust ignore")]
+#[cfg_attr(feature = "bevy_auto_plugin", doc = "```rust")]
+/// # use bevy_app::prelude::*;
 /// # use bevy_ecs::prelude::*;
 /// # use immediate_stats::*;
-/// #[butler_plugin]
+/// # use bevy_auto_plugin::modes::global::prelude::{AutoPlugin, auto_component, auto_init_resource};
+/// #[derive(AutoPlugin)]
+/// #[auto_plugin(impl_plugin_trait)]
 /// struct MyPlugin;
 ///
-/// // `StatContainer` derive adds the `add_component` attribute
-/// // and hooks into the existing `insert_resource` macro.
-/// #[derive(StatContainer, Component, Resource, Default)]
-/// #[add_component(plugin = MyPlugin)] // Adds `reset_component_modifiers` system.
-/// #[insert_resource(plugin = MyPlugin)] // Adds `reset_resource_modifiers` system.
+/// // `StatContainer` derive hooks into the existing `auto_component` and `auto_resource` macros.
+/// #[derive(StatContainer, Component, Resource)]
+/// #[auto_component(plugin = MyPlugin)] // Adds `reset_component_modifiers` system.
+/// #[auto_init_resource(plugin = MyPlugin)] // Adds `reset_resource_modifiers` system.
 /// struct Speed(Stat);
 /// ```
 pub use immediate_stats_macros::StatContainer;

--- a/immediate_stats/src/lib.rs
+++ b/immediate_stats/src/lib.rs
@@ -59,7 +59,7 @@
 //! # use bevy_app::prelude::*;
 //! # use bevy_ecs::prelude::*;
 //! # use immediate_stats::*;
-//! # use bevy_auto_plugin::modes::global::prelude::{AutoPlugin, auto_component, auto_init_resource};
+//! # use bevy_auto_plugin::modes::global::prelude::{AutoPlugin, auto_component, auto_resource};
 //! fn main() {
 //!     App::new().add_plugins((ImmediateStatsPlugin, MyPlugin)).run();
 //! }
@@ -71,7 +71,7 @@
 //! // `StatContainer` derive hooks into the existing `auto_component` and `auto_resource` macros.
 //! #[derive(StatContainer, Component, Resource)]
 //! #[auto_component(plugin = MyPlugin)] // Adds `reset_component_modifiers` system.
-//! #[auto_init_resource(plugin = MyPlugin)] // Adds `reset_resource_modifiers` system.
+//! #[auto_resource(plugin = MyPlugin)] // Adds `reset_resource_modifiers` system.
 //! struct Speed(Stat);
 //! ```
 //!
@@ -149,7 +149,7 @@ mod stat;
 /// # use bevy_app::prelude::*;
 /// # use bevy_ecs::prelude::*;
 /// # use immediate_stats::*;
-/// # use bevy_auto_plugin::modes::global::prelude::{AutoPlugin, auto_component, auto_init_resource};
+/// # use bevy_auto_plugin::modes::global::prelude::{AutoPlugin, auto_component, auto_resource};
 /// #[derive(AutoPlugin)]
 /// #[auto_plugin(impl_plugin_trait)]
 /// struct MyPlugin;
@@ -157,7 +157,7 @@ mod stat;
 /// // `StatContainer` derive hooks into the existing `auto_component` and `auto_resource` macros.
 /// #[derive(StatContainer, Component, Resource)]
 /// #[auto_component(plugin = MyPlugin)] // Adds `reset_component_modifiers` system.
-/// #[auto_init_resource(plugin = MyPlugin)] // Adds `reset_resource_modifiers` system.
+/// #[auto_resource(plugin = MyPlugin)] // Adds `reset_resource_modifiers` system.
 /// struct Speed(Stat);
 /// ```
 pub use immediate_stats_macros::StatContainer;

--- a/immediate_stats/tests/bevy_auto_plugin.rs
+++ b/immediate_stats/tests/bevy_auto_plugin.rs
@@ -1,0 +1,61 @@
+//! Tests the `add_component` attribute for automatic system registration.
+#![cfg(feature = "bevy_auto_plugin")]
+
+extern crate immediate_stats;
+use crate::{Stat, StatContainer};
+use bevy_app::App;
+use bevy_auto_plugin::modes::global::prelude::{AutoPlugin, auto_component, auto_init_resource};
+use bevy_ecs::prelude::*;
+use immediate_stats::*;
+
+#[derive(AutoPlugin)]
+#[auto_plugin(impl_plugin_trait)]
+struct MyPlugin;
+
+#[derive(Resource, Component, StatContainer, Default, PartialEq, Debug)]
+#[auto_component(plugin = MyPlugin)]
+#[auto_init_resource(plugin = MyPlugin)]
+struct Health(Stat);
+
+#[test]
+fn reset_component_auto() {
+    let mut app = App::new();
+
+    app.add_plugins(MyPlugin);
+
+    let entity = app
+        .world_mut()
+        .spawn(Health(Stat {
+            base: 100,
+            bonus: 50,
+            multiplier: 2.0,
+        }))
+        .id();
+
+    app.update();
+
+    assert_eq!(
+        app.world().get::<Health>(entity),
+        Some(Health(Stat::new(100))).as_ref()
+    );
+}
+
+#[test]
+fn reset_resource_auto() {
+    let mut app = App::new();
+
+    app.add_plugins(MyPlugin);
+
+    app.insert_resource(Health(Stat {
+        base: 100,
+        bonus: 50,
+        multiplier: 2.0,
+    }));
+
+    app.update();
+
+    assert_eq!(
+        app.world().get_resource::<Health>(),
+        Some(Health(Stat::new(100))).as_ref()
+    );
+}

--- a/immediate_stats_macros/Cargo.toml
+++ b/immediate_stats_macros/Cargo.toml
@@ -19,9 +19,10 @@ proc-macro = true
 [features]
 bevy = []
 bevy_butler = ["bevy"]
+bevy_auto_plugin = ["bevy"]
 
 [dependencies]
-darling = "0.20.11"
+darling = "0.21.3"
 proc-macro2 = "1.0"
 proc-macro-error = "1.0"
 quote = "1.0"

--- a/immediate_stats_macros/Cargo.toml
+++ b/immediate_stats_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "immediate_stats_macros"
-version = "0.1.3"
+version = "0.2.0-beta.1"
 edition = "2024"
 description = "Game stats that reset every frame, inspired by immediate mode GUI."
 categories = ["game-development", "data-structures"]

--- a/immediate_stats_macros/src/bevy_auto_plugin.rs
+++ b/immediate_stats_macros/src/bevy_auto_plugin.rs
@@ -58,7 +58,7 @@ impl<'a> ToTokens for AutoPluginAttributes<'a> {
                     )
                 )]
                 fn #system_ident(
-                    mut query: Query<&mut #ident, Without<PauseStatReset>>,
+                    mut query: Query<&mut #ident, Without<immediate_stats::PauseStatReset>>,
                 ) {
                     for mut stat in &mut query {
                         stat.reset_modifiers();

--- a/immediate_stats_macros/src/bevy_auto_plugin.rs
+++ b/immediate_stats_macros/src/bevy_auto_plugin.rs
@@ -4,32 +4,35 @@ use proc_macro2::{Ident, TokenStream};
 use quote::{ToTokens, format_ident, quote};
 use syn::{DeriveInput, Expr, Meta, Path};
 
-/// Returns code that will register stat resetting system(s) with Bevy Butler.
+/// Returns code that will register stat resetting system(s) with Bevy Auto Plugin.
 pub fn register_systems(input: &DeriveInput) -> darling::Result<TokenStream> {
     let struct_name = &input.ident;
 
-    let mut butler_attributes = ButlerAttributes::new(struct_name);
+    let mut auto_plugin_attributes = AutoPluginAttributes::new(struct_name);
 
     for attr in &input.attrs {
-        if attr.path().is_ident("add_component") {
+        if attr.path().is_ident("auto_component") {
             let plugin = PluginPath::from_meta(&attr.meta)?;
-            butler_attributes.component_plugin = Some(plugin);
-        } else if attr.path().is_ident("insert_resource") {
+            auto_plugin_attributes.component_plugin = Some(plugin);
+        } else if attr.path().is_ident("auto_resource")
+            || attr.path().is_ident("auto_init_resource")
+            || attr.path().is_ident("auto_insert_resource")
+        {
             let plugin = PluginPath::from_meta(&attr.meta)?;
-            butler_attributes.resource_plugin = Some(plugin);
+            auto_plugin_attributes.resource_plugin = Some(plugin);
         }
     }
 
-    Ok(butler_attributes.into_token_stream())
+    Ok(auto_plugin_attributes.into_token_stream())
 }
 
-pub struct ButlerAttributes<'a> {
+pub struct AutoPluginAttributes<'a> {
     ident: &'a Ident,
     component_plugin: Option<PluginPath>,
     resource_plugin: Option<PluginPath>,
 }
 
-impl<'a> ButlerAttributes<'a> {
+impl<'a> AutoPluginAttributes<'a> {
     pub fn new(ident: &'a Ident) -> Self {
         Self {
             ident,
@@ -39,7 +42,7 @@ impl<'a> ButlerAttributes<'a> {
     }
 }
 
-impl<'a> ToTokens for ButlerAttributes<'a> {
+impl<'a> ToTokens for AutoPluginAttributes<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         if let Some(plugin_path) = &self.component_plugin {
             let ident = &self.ident;
@@ -49,11 +52,13 @@ impl<'a> ToTokens for ButlerAttributes<'a> {
             // Due to some strange import scoping issues, we cannot use the plugins.
             // Instead, we can just recreate the plugin's functionality.
             tokens.extend(quote! {
-                #[bevy_butler::add_system(
-                    generics = <#ident>,
+                #[bevy_auto_plugin::modes::global::prelude::auto_system(
+                    generics(#ident),
                     plugin = #plugin,
                     schedule = immediate_stats::__PreUpdate,
-                    in_set = immediate_stats::StatSystems::Reset,
+                    config(
+                        in_set = immediate_stats::StatSystems::Reset,
+                    )
                 )]
                 use immediate_stats::reset_component_modifiers as #use_as;
             });
@@ -67,11 +72,13 @@ impl<'a> ToTokens for ButlerAttributes<'a> {
             // Due to some strange import scoping issues, we cannot use the plugins.
             // Instead, we can just recreate the plugin's functionality.
             tokens.extend(quote! {
-                #[bevy_butler::add_system(
-                    generics = <#ident>,
+                #[bevy_auto_plugin::modes::global::prelude::auto_system(
+                    generics(#ident),
                     plugin = #plugin,
                     schedule = immediate_stats::__PreUpdate,
-                    in_set = immediate_stats::StatSystems::Reset,
+                    config(
+                        in_set = immediate_stats::StatSystems::Reset,
+                    )
                 )]
                 use immediate_stats::reset_resource_modifiers as #use_as;
             });
@@ -107,7 +114,7 @@ impl FromMeta for PluginPath {
                     }
                     Meta::NameValue(name_value) => match &name_value.value {
                         Expr::Path(p) => Ok(PluginPath(p.path.clone())),
-                        _ => Err(Error::custom("Expected a path to a butler plugin")),
+                        _ => Err(Error::custom("Expected a path to an auto plugin")),
                     },
                 },
                 NestedMeta::Lit(_) => Err(Error::custom("Expected `plugin` attribute")),


### PR DESCRIPTION
This will replace `bevy_butler`, which is [now depreciated](https://github.com/TGRCdev/bevy-butler/pull/35). The `bevy_butler` feature flag is now depreciated, and will likely be removed in the next release.